### PR TITLE
Add mission info with images

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>О проекте</title>
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
   <header>
@@ -17,7 +17,8 @@
   <main>
     <div class="card">
       <p>Этот сайт демонстрирует посадочные площадки различных лунных миссий.</p>
-      <p>Использованы данные NASA и Wikipedia.</p>
+      <p>Использованы данные NASA и Wikipedia. Трёхмерная модель Луны построена на Three.js и содержит интерактивные метки, ведущие на страницы с описанием миссий.</p>
+      <p>Материалы предназначены исключительно в образовательных целях.</p>
     </div>
   </main>
   <footer>

--- a/apollo-11.html
+++ b/apollo-11.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Apollo 11</title>
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
   <header>
@@ -17,8 +17,10 @@
   </header>
   <main>
     <div class="card">
-      <p>Здесь будет информация о миссии Apollo 11.</p>
-      <p>Фото и ссылки появятся позже.</p>
+      <img src="https://www.nasa.gov/sites/default/files/thumbnails/image/as11-40-5874.jpg" alt="Apollo 11 on the Moon" />
+      <p><strong>Apollo 11</strong> стала первой миссией, доставившей людей на Луну. 20 июля 1969 года Нил Армстронг и Базз Олдрин совершили посадку в Море Спокойствия, а Майкл Коллинз оставался на орбите.</p>
+      <p>Экипаж выполнил короткую прогулку по поверхности и собрал образцы грунта, принеся человечеству знаменитую фразу «one small step for man».</p>
+      <p><a href="https://ru.wikipedia.org/wiki/Apollo_11" target="_blank" rel="noopener">Подробнее на Википедии</a></p>
     </div>
   </main>
   <footer>

--- a/apollo-12.html
+++ b/apollo-12.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Apollo 12</title>
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
   <header>
@@ -17,8 +17,10 @@
   </header>
   <main>
     <div class="card">
-      <p>Здесь будет информация о миссии Apollo 12.</p>
-      <p>Фото и ссылки появятся позже.</p>
+      <img src="https://www.nasa.gov/sites/default/files/thumbnails/image/apollo_12_sample_collection.jpg" alt="Apollo 12 astronauts" />
+      <p><strong>Apollo 12</strong> приземлилась на Луну 19 ноября 1969 года всего в нескольких сотнях метров от зонда Surveyor 3. Командир Чарльз Конрад и пилот Алан Бин провели почти день и собрали обширные образцы грунта.</p>
+      <p>Миссия доказала точность посадки лунного модуля и укрепила уверенность в долговременных исследованиях.</p>
+      <p><a href="https://ru.wikipedia.org/wiki/Apollo_12" target="_blank" rel="noopener">Подробнее на Википедии</a></p>
     </div>
   </main>
   <footer>

--- a/apollo-17.html
+++ b/apollo-17.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Apollo 17</title>
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
   <header>
@@ -17,8 +17,10 @@
   </header>
   <main>
     <div class="card">
-      <p>Здесь будет информация о миссии Apollo 17.</p>
-      <p>Фото и ссылки появятся позже.</p>
+      <img src="https://www.nasa.gov/sites/default/files/thumbnails/image/apollo17_cernan.jpg" alt="Apollo 17 mission" />
+      <p><strong>Apollo 17</strong> — шестая и последняя экспедиция программы, высадившаяся на Луне. В декабре 1972 года Юджин Сернан и Харрисон Шмитт работали в долине Тавр-Литтров, в то время как Рональд Эванс оставался на орбите.</p>
+      <p>Эта миссия установила рекорд по количеству собранного лунного материала и стала последним визитом людей на Луну в XX веке.</p>
+      <p><a href="https://ru.wikipedia.org/wiki/Apollo_17" target="_blank" rel="noopener">Подробнее на Википедии</a></p>
     </div>
   </main>
   <footer>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Луна</title>
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
   <header>
@@ -15,6 +15,9 @@
     </nav>
   </header>
   <main>
+    <div class="card">
+      <p>Исследуйте Луну в 3D и кликайте по меткам, чтобы узнать об исторических миссиях.</p>
+    </div>
     <div id="canvas-container"></div>
     <div id="tooltip" class="hidden"></div>
     <button id="toggle-markers">Показать все метки</button>

--- a/luna-2.html
+++ b/luna-2.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Luna 2</title>
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
   <header>
@@ -17,8 +17,10 @@
   </header>
   <main>
     <div class="card">
-      <p>Здесь будет информация о миссии Luna 2.</p>
-      <p>Фото и ссылки появятся позже.</p>
+      <img src="https://www.nasa.gov/sites/default/files/thumbnails/image/668911main_GPN-2000-001210_full.jpg" alt="Luna 2" />
+      <p><strong>Luna 2</strong> — советская автоматическая станция, впервые в истории достигшая поверхности Луны. 14 сентября 1959 года аппарат совершил жёсткую посадку в районе Моря Ясности.</p>
+      <p>Успех миссии стал важнейшим этапом освоения космоса и подтвердил возможность межпланетных перелётов.</p>
+      <p><a href="https://ru.wikipedia.org/wiki/%D0%9B%D1%83%D0%BD%D0%B0-2" target="_blank" rel="noopener">Подробнее на Википедии</a></p>
     </div>
   </main>
   <footer>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: 'Orbitron', sans-serif;
+  font-family: 'Roboto', 'Orbitron', sans-serif;
   background: #000 url('https://threejs.org/examples/textures/starfield.jpg') center/cover fixed;
   color: #fff;
 }
@@ -74,4 +74,10 @@ footer a {
   padding: 20px;
   border-radius: 10px;
   box-shadow: 0 0 10px rgba(0,0,0,0.5);
+}
+
+.card img {
+  width: 100%;
+  border-radius: 10px;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- enrich each mission page with brief history and NASA photos
- improve description on About page
- add intro card on main page
- tweak fonts and styles for a modern look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f4de724dc8331bd1e145b5da6177a